### PR TITLE
Pull request

### DIFF
--- a/setup_meter
+++ b/setup_meter
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 ##
 ### Copyright 2011, Boundary
 ###
@@ -13,8 +15,6 @@
 ### See the License for the specific language governing permissions and
 ### limitations under the License.
 ###
-
-#!/bin/bash
 
 # ARCHS=("i686" "x86_64")
 PLATFORMS=("Ubuntu" "Debian" "CentOS")
@@ -66,14 +66,14 @@ function print_supported_platforms() {
     echo "Your platform is not supported. Supported platforms are:"
     for d in ${PLATFORMS[*]}
     do
-	echo -n $d:
-	foo="\${${d}_VERSIONS[*]}"
-	versions=`eval echo $foo`
-	for v in $versions
-	do
-	    echo -n " $v"
-	done
-	echo ""
+  echo -n $d:
+  foo="\${${d}_VERSIONS[*]}"
+  versions=`eval echo $foo`
+  for v in $versions
+  do
+      echo -n " $v"
+  done
+  echo ""
     done
 
     exit 0
@@ -87,53 +87,53 @@ function check_distro_version() {
     VERSIONS=`eval echo $TEMP`
 
     if [ $DISTRO = "Ubuntu" ]; then
-	VERSION=`echo $PLATFORM | awk '{print $2}'`
+  VERSION=`echo $PLATFORM | awk '{print $2}'`
 
-	MAJOR_VERSION=`echo $VERSION | awk -F. '{print $1}'`
-	MINOR_VERSION=`echo $VERSION | awk -F. '{print $2}'`
-	PATCH_VERSION=`echo $VERSION | awk -F. '{print $3}'`
+  MAJOR_VERSION=`echo $VERSION | awk -F. '{print $1}'`
+  MINOR_VERSION=`echo $VERSION | awk -F. '{print $2}'`
+  PATCH_VERSION=`echo $VERSION | awk -F. '{print $3}'`
 
-	TEMP="\${${DISTRO}_VERSIONS[*]}"
-	VERSIONS=`eval echo $TEMP`
-	for v in $VERSIONS ; do
-	    if [ "$MAJOR_VERSION.$MINOR_VERSION" = "$v" ]; then
-		return 0
-	    fi
-	done
+  TEMP="\${${DISTRO}_VERSIONS[*]}"
+  VERSIONS=`eval echo $TEMP`
+  for v in $VERSIONS ; do
+      if [ "$MAJOR_VERSION.$MINOR_VERSION" = "$v" ]; then
+    return 0
+      fi
+  done
 
     elif [ $DISTRO = "CentOS" ]; then
-	# Works for centos 5
-	VERSION=`echo $PLATFORM | awk '{print $3}'`
+  # Works for centos 5
+  VERSION=`echo $PLATFORM | awk '{print $3}'`
 
         # Hack for centos 6
-	if [ $VERSION = "release" ]; then
-	    VERSION=`echo $PLATFORM | awk '{print $4}'`
-	fi
+  if [ $VERSION = "release" ]; then
+      VERSION=`echo $PLATFORM | awk '{print $4}'`
+  fi
 
-	MAJOR_VERSION=`echo $VERSION | awk -F. '{print $1}'`
-	MINOR_VERSION=`echo $VERSION | awk -F. '{print $2}'`
+  MAJOR_VERSION=`echo $VERSION | awk -F. '{print $1}'`
+  MINOR_VERSION=`echo $VERSION | awk -F. '{print $2}'`
 
-	TEMP="\${${DISTRO}_VERSIONS[*]}"
-	VERSIONS=`eval echo $TEMP`
-	for v in $VERSIONS ; do
-	    if [ "$MAJOR_VERSION" = "$v" ]; then
-		return 0
-	    fi
-	done
+  TEMP="\${${DISTRO}_VERSIONS[*]}"
+  VERSIONS=`eval echo $TEMP`
+  for v in $VERSIONS ; do
+      if [ "$MAJOR_VERSION" = "$v" ]; then
+    return 0
+      fi
+  done
 
     elif [ $DISTRO = "Debian" ]; then
-	VERSION=`echo $PLATFORM | awk '{print $3}'`
+  VERSION=`echo $PLATFORM | awk '{print $3}'`
 
-	MAJOR_VERSION=`echo $VERSION | awk -F. '{print $1}'`
-	MINOR_VERSION=`echo $VERSION | awk -F. '{print $2}'`
+  MAJOR_VERSION=`echo $VERSION | awk -F. '{print $1}'`
+  MINOR_VERSION=`echo $VERSION | awk -F. '{print $2}'`
 
-	TEMP="\${${DISTRO}_VERSIONS[*]}"
-	VERSIONS=`eval echo $TEMP`
-	for v in $VERSIONS ; do
-	    if [ "$MAJOR_VERSION" = "$v" ]; then
-		return 0
-	    fi
-	done
+  TEMP="\${${DISTRO}_VERSIONS[*]}"
+  VERSIONS=`eval echo $TEMP`
+  for v in $VERSIONS ; do
+      if [ "$MAJOR_VERSION" = "$v" ]; then
+    return 0
+      fi
+  done
     fi
 
     echo "Detected $DISTRO but with an unsupported version ($MAJOR_VERSION.$MINOR_VERSION)"
@@ -193,6 +193,12 @@ function create_meter() {
     echo "can be found in the Account Settings in the Boundary WebUI."
     exit 1
 
+  elif [ "$STATUS" = "403" ]; then
+    echo "Forbidden error (http status $STATUS)."
+    echo "Verify that you have not exceeded your meter limit."
+    echo "If you haven't, please contact support at support@boundary.com."
+    exit 1
+
   else
     if [ "$STATUS" = "201" ] || [ "$STATUS" = "409" ]; then
       echo $RESULT | awk '{print $2}'
@@ -206,48 +212,48 @@ function create_meter() {
 
 function do_install() {
     if [ "$DISTRO" = "Ubuntu" ]; then
-	sudo $APT_CMD update > /dev/null
+  sudo $APT_CMD update > /dev/null
 
-	APT_STRING="deb https://apt.boundary.com/ubuntu/ `get $DISTRO $MAJOR_VERSION.$MINOR_VERSION` universe"
-	echo "Adding repository $APT_STRING"
-	sudo sh -c "echo \"$APT_STRING\" > /etc/apt/sources.list.d/boundary.list"
+  APT_STRING="deb https://apt.boundary.com/ubuntu/ `get $DISTRO $MAJOR_VERSION.$MINOR_VERSION` universe"
+  echo "Adding repository $APT_STRING"
+  sudo sh -c "echo \"$APT_STRING\" > /etc/apt/sources.list.d/boundary.list"
 
-	$CURL -s https://$APT/APT-GPG-KEY-Boundary | sudo apt-key add -
-	if [ $? -gt 0 ]; then
-	    echo "Error downloading GPG key from https://$APT/APT-GPG-KEY-Boundary!"
-	    exit 1
-	fi
+  $CURL -s https://$APT/APT-GPG-KEY-Boundary | sudo apt-key add -
+  if [ $? -gt 0 ]; then
+      echo "Error downloading GPG key from https://$APT/APT-GPG-KEY-Boundary!"
+      exit 1
+  fi
 
-	sudo $APT_CMD update > /dev/null
-	sudo $APT_CMD install bprobe
-	return $?
+  sudo $APT_CMD update > /dev/null
+  sudo $APT_CMD install bprobe
+  return $?
     elif [ "$DISTRO" = "Debian" ]; then
-	sudo $APT_CMD update > /dev/null
+  sudo $APT_CMD update > /dev/null
 
-	APT_STRING="deb https://apt.boundary.com/debian/ `get $DISTRO $MAJOR_VERSION` main"
-	echo "Adding repository $APT_STRING"
-	sudo sh -c "echo \"$APT_STRING\" > /etc/apt/sources.list.d/boundary.list"
+  APT_STRING="deb https://apt.boundary.com/debian/ `get $DISTRO $MAJOR_VERSION` main"
+  echo "Adding repository $APT_STRING"
+  sudo sh -c "echo \"$APT_STRING\" > /etc/apt/sources.list.d/boundary.list"
 
-	$CURL -s https://$APT/APT-GPG-KEY-Boundary | sudo apt-key add -
-	if [ $? -gt 0 ]; then
-	    echo "Error downloading GPG key from https://$APT/APT-GPG-KEY-Boundary!"
-	    exit 1
-	fi
+  $CURL -s https://$APT/APT-GPG-KEY-Boundary | sudo apt-key add -
+  if [ $? -gt 0 ]; then
+      echo "Error downloading GPG key from https://$APT/APT-GPG-KEY-Boundary!"
+      exit 1
+  fi
 
-	sudo $APT_CMD update > /dev/null
-	sudo $APT_CMD install bprobe
-	return $?
+  sudo $APT_CMD update > /dev/null
+  sudo $APT_CMD install bprobe
+  return $?
     elif [ "$DISTRO" = "CentOS" ]; then
-	GPG_KEY_LOCATION=/etc/pki/rpm-gpg/RPM-GPG-KEY-Boundary
-	if [ $MACHINE = "i686" ]; then
-	    ARCH_STR="i386/"
-	elif [ $MACHINE = "x86_64" ]; then
-	    ARCH_STR="x86_64/"
-	fi
+  GPG_KEY_LOCATION=/etc/pki/rpm-gpg/RPM-GPG-KEY-Boundary
+  if [ $MACHINE = "i686" ]; then
+      ARCH_STR="i386/"
+  elif [ $MACHINE = "x86_64" ]; then
+      ARCH_STR="x86_64/"
+  fi
 
-	echo "Adding repository http://yum.boundary.com/centos/os/$MAJOR_VERSION/$ARCH_STR"
+  echo "Adding repository http://yum.boundary.com/centos/os/$MAJOR_VERSION/$ARCH_STR"
 
-	sudo sh -c "cat - > /etc/yum.repos.d/boundary.repo <<EOF
+  sudo sh -c "cat - > /etc/yum.repos.d/boundary.repo <<EOF
 [boundary]
 name=boundary
 baseurl=http://yum.boundary.com/centos/os/$MAJOR_VERSION/$ARCH_STR
@@ -256,14 +262,14 @@ gpgkey=file://$GPG_KEY_LOCATION
 enabled=1
 EOF"
 
-	$CURL -s https://$YUM/RPM-GPG-KEY-Boundary | sudo tee /etc/pki/rpm-gpg/RPM-GPG-KEY-Boundary > /dev/null
-	if [ $? -gt 0 ]; then
-	    echo "Error downloading GPG key from https://$YUM/RPM-GPG-KEY-Boundary!"
-	    exit 1
-	fi
+  $CURL -s https://$YUM/RPM-GPG-KEY-Boundary | sudo tee /etc/pki/rpm-gpg/RPM-GPG-KEY-Boundary > /dev/null
+  if [ $? -gt 0 ]; then
+      echo "Error downloading GPG key from https://$YUM/RPM-GPG-KEY-Boundary!"
+      exit 1
+  fi
 
-	sudo $YUM_CMD install bprobe
-	return $?
+  sudo $YUM_CMD install bprobe
+  return $?
     fi
 }
 
@@ -382,52 +388,52 @@ function ec2_tag() {
 function pre_install_sanity() {
     SUDO=`which sudo`
     if [ $? -ne 0 ]; then
-	echo "This script requires that sudo be installed and configured for your user."
-	echo "Please install sudo. For assistance, support@boundary.com"
-	exit 1
+  echo "This script requires that sudo be installed and configured for your user."
+  echo "Please install sudo. For assistance, support@boundary.com"
+  exit 1
     fi
 
     which curl > /dev/null
     if [ $? -gt 0 ]; then
-	echo "The 'curl' command is either not installed or not on the PATH ..."
+  echo "The 'curl' command is either not installed or not on the PATH ..."
 
-	if [ $DEPS = "true" ]; then
-	    echo "Installing curl ..."
+  if [ $DEPS = "true" ]; then
+      echo "Installing curl ..."
 
-	    if [ $DISTRO = "Ubuntu" ] || [ $DISTRO = "Debian" ]; then
-		sudo $APT_CMD update > /dev/null
-		sudo $APT_CMD install curl
+      if [ $DISTRO = "Ubuntu" ] || [ $DISTRO = "Debian" ]; then
+    sudo $APT_CMD update > /dev/null
+    sudo $APT_CMD install curl
 
-	    elif [ $DISTRO = "CentOS" ]; then
-		if [ $MACHINE = "i686" ]; then
-		    sudo $YUM_CMD install curl.i686
-		fi
+      elif [ $DISTRO = "CentOS" ]; then
+    if [ $MACHINE = "i686" ]; then
+        sudo $YUM_CMD install curl.i686
+    fi
 
-		if [ $MACHINE = "x86_64" ]; then
-		    sudo $YUM_CMD install curl.x86_64
-		fi
-	    fi
-	else
-	    echo "To automatically install required components for Meter Install, rerun setup_meter.sh with -d flag."
-	    exit 1
-	fi
+    if [ $MACHINE = "x86_64" ]; then
+        sudo $YUM_CMD install curl.x86_64
+    fi
+      fi
+  else
+      echo "To automatically install required components for Meter Install, rerun setup_meter.sh with -d flag."
+      exit 1
+  fi
     fi
     CURL="`which curl` --sslv3"
 
     if [ $DISTRO = "Ubuntu" ] || [ $DISTRO = "Debian" ]; then
-	test -f /usr/lib/apt/methods/https
-	if [ $? -gt 0 ];then
-	    echo "apt-transport-https is not installed to access Boundary's HTTPS based APT repository ..."
+  test -f /usr/lib/apt/methods/https
+  if [ $? -gt 0 ];then
+      echo "apt-transport-https is not installed to access Boundary's HTTPS based APT repository ..."
 
-	    if [ $DEPS = "true" ]; then
-		echo "Installing apt-transport-https ..."
-		sudo $APT_CMD update > /dev/null
-		sudo $APT_CMD install apt-transport-https
-	    else
-		echo "To automatically install required components for Meter Install, rerun setup_meter.sh with -d flag."
-		exit 1
-	    fi
-	fi
+      if [ $DEPS = "true" ]; then
+    echo "Installing apt-transport-https ..."
+    sudo $APT_CMD update > /dev/null
+    sudo $APT_CMD install apt-transport-https
+      else
+    echo "To automatically install required components for Meter Install, rerun setup_meter.sh with -d flag."
+    exit 1
+      fi
+  fi
     fi
 }
 
@@ -446,10 +452,10 @@ fi
 
 while getopts "h di:" opts; do
     case $opts in
-	h) print_help;;
-	d) DEPS="true";;
-	i) APICREDS="$OPTARG";;
-	[?]) print_help;;
+  h) print_help;;
+  d) DEPS="true";;
+  i) APICREDS="$OPTARG";;
+  [?]) print_help;;
     esac
 done
 
@@ -481,8 +487,8 @@ fi
 # Check the distribution
 for d in ${PLATFORMS[*]} ; do
     if [ $DISTRO = $d ]; then
-	SUPPORTED_PLATFORM=1
-	break
+  SUPPORTED_PLATFORM=1
+  break
     fi
 done
 if [ $SUPPORTED_PLATFORM -eq 0 ]; then
@@ -506,7 +512,7 @@ METER_LOCATION=`create_meter $APIKEY $APIID`
 if [ $? -gt 0 ]; then
     echo "Error creating meter:"
     echo "$METER_LOCATION"
-    echo "Please contact support@boundary.com"
+#    echo "Please contact support@boundary.com"
     exit 1
 fi
 

--- a/setup_meter
+++ b/setup_meter
@@ -141,7 +141,7 @@ function check_distro_version() {
 }
 
 function print_help() {
-  echo "   ./meter_setup.sh [-d] -i ORGID:APIKEY"
+  echo "   $0 [-d] -i ORGID:APIKEY"
   echo "      -i: Required input for authentication. The ORGID and APIKEY can be found"
   echo "          in the Account Settings in the Boundary WebUI."
   echo "      -d: Optional flag to install all dependencies, such as curl and"
@@ -414,7 +414,7 @@ function pre_install_sanity() {
     fi
       fi
   else
-      echo "To automatically install required components for Meter Install, rerun setup_meter.sh with -d flag."
+      echo "To automatically install required components for Meter Install, rerun $0 with -d flag."
       exit 1
   fi
     fi
@@ -430,7 +430,7 @@ function pre_install_sanity() {
     sudo $APT_CMD update > /dev/null
     sudo $APT_CMD install apt-transport-https
       else
-    echo "To automatically install required components for Meter Install, rerun setup_meter.sh with -d flag."
+    echo "To automatically install required components for Meter Install, rerun $0 with -d flag."
     exit 1
       fi
   fi


### PR DESCRIPTION
Put Bash shebang at top - otherwise it's ignored (no -x added for debugging, etc.)

Added 403 handling.  Mine was a result of excess meters, but it may vary.

Commented "contact support" generic, as a "contact support" request is already in the error handlers.

Switched setup_meter.sh and meter_setup.sh (both were there!) references to "$0."

Renamed file to setup_meter - it's Bash, not .sh, and removing the extension makes it more flexible for you to rewrite the script in a language of your choosing without having to update docs or linking scripts.
