### PR TITLE
Correctly determine OS distro and versions

### DIFF
--- a/setup_meter.sh
+++ b/setup_meter.sh
@@ -444,8 +444,9 @@ if [ -f /etc/redhat-release ] ; then
 elif [ -f /etc/lsb-release ] ; then
     #Ubuntu version lsb-release - https://help.ubuntu.com/community/CheckingYourUbuntuVersion
     . /etc/lsb-release
-    PLATFORM=$DISTRIB_ID
-    DISTRO=$DISTRIB_RELEASE
+    PLATFORM=$DISTRIB_DESCRIPTION
+    DISTRO=$DISTRIB_ID
+    VERSION=$DISTRIB_RELEASE
     MACHINE=`uname -m`
 elif [ -f /etc/debian_version ] ; then
     #Debian Version /etc/debian_version - Source: http://www.debian.org/doc/manuals/debian-faq/ch-software.en.html#s-isitdebian

--- a/setup_meter.sh
+++ b/setup_meter.sh
@@ -437,15 +437,21 @@ function pre_install_sanity() {
 }
 
 # Grab some system information
-test -f /etc/issue
-if [ $? -eq 0 ]; then
-    PLATFORM=`cat /etc/issue | head -n 1`
-    DISTRO=`echo $PLATFORM | awk '{print $1}'`
-    MACHINE=`uname -m`
+if [ $DISTRO = "CentOS" ] ; then
+         PLATFORM=`cat /etc/redhat-release | head -n 1`
+         DISTRO=`echo $PLATFORM | awk '{print $1}'`
+         MACHINE=`uname -m`
 else
-    PLATFORM="unknown"
-    DISTRO="unknown"
-    MACHINE=`uname -m`
+    test -f /etc/issue
+    if [ $? -eq 0 ]; then
+        PLATFORM=`cat /etc/issue | head -n 1`
+        DISTRO=`echo $PLATFORM | awk '{print $1}'`
+        MACHINE=`uname -m`
+    else
+        PLATFORM="unknown"
+        DISTRO="unknown"
+        MACHINE=`uname -m`
+    fi
 fi
 
 

--- a/setup_meter.sh
+++ b/setup_meter.sh
@@ -444,8 +444,8 @@ if [ -f /etc/redhat-release ] ; then
 elif [ -f /etc/lsb-release ] ; then
     #Ubuntu version lsb-release - https://help.ubuntu.com/community/CheckingYourUbuntuVersion
     . /etc/lsb-release
-    OS=$DISTRIB_ID
-    VER=$DISTRIB_RELEASE
+    PLATFORM=$DISTRIB_ID
+    DISTRO=$DISTRIB_RELEASE
     MACHINE=`uname -m`
 elif [ -f /etc/debian_version ] ; then
     #Debian Version /etc/debian_version - Source: http://www.debian.org/doc/manuals/debian-faq/ch-software.en.html#s-isitdebian

--- a/setup_meter.sh
+++ b/setup_meter.sh
@@ -81,12 +81,13 @@ function print_supported_platforms() {
 function check_distro_version() {
     PLATFORM=$1
     DISTRO=$2
+    VERSION=$3
 
     TEMP="\${${DISTRO}_versions[*]}"
     VERSIONS=`eval echo $TEMP`
 
     if [ $DISTRO = "Ubuntu" ]; then
-        VERSION=`echo $PLATFORM | awk '{print $2}'`
+        #VERSION=`echo $PLATFORM | awk '{print $2}'`
 
         MAJOR_VERSION=`echo $VERSION | awk -F. '{print $1}'`
         MINOR_VERSION=`echo $VERSION | awk -F. '{print $2}'`
@@ -102,12 +103,12 @@ function check_distro_version() {
 
     elif [ $DISTRO = "CentOS" ]; then
         # Works for centos 5
-        VERSION=`echo $PLATFORM | awk '{print $3}'`
+        #VERSION=`echo $PLATFORM | awk '{print $3}'`
 
         # Hack for centos 6
-        if [ $VERSION = "release" ]; then
-            VERSION=`echo $PLATFORM | awk '{print $4}'`
-        fi
+        #if [ $VERSION = "release" ]; then
+        #    VERSION=`echo $PLATFORM | awk '{print $4}'`
+        #fi
 
         MAJOR_VERSION=`echo $VERSION | awk -F. '{print $1}'`
         MINOR_VERSION=`echo $VERSION | awk -F. '{print $2}'`
@@ -121,7 +122,7 @@ function check_distro_version() {
         done
 
     elif [ $DISTRO = "Debian" ]; then
-        VERSION=`echo $PLATFORM | awk '{print $3}'`
+        #VERSION=`echo $PLATFORM | awk '{print $3}'`
 
         MAJOR_VERSION=`echo $VERSION | awk -F. '{print $1}'`
         MINOR_VERSION=`echo $VERSION | awk -F. '{print $2}'`
@@ -451,8 +452,10 @@ elif [ -f /etc/lsb-release ] ; then
     MACHINE=`uname -m`
 elif [ -f /etc/debian_version ] ; then
     #Debian Version /etc/debian_version - Source: http://www.debian.org/doc/manuals/debian-faq/ch-software.en.html#s-isitdebian
-    PLATFORM=`cat /etc/debian_version | head -n 1`
-    DISTRO=`echo $PLATFORM | awk '{print $1}'`
+    DISTRO="Debian"
+    VERSION=`cat /etc/debian_version`
+    INFO="$DISTRO $VERSION"
+    PLATFORM=$INFO
     MACHINE=`uname -m`
 else
     PLATFORM="unknown"
@@ -522,7 +525,7 @@ if [ $SUPPORTED_PLATFORM -eq 0 ]; then
 fi
 
 # Check the version number
-check_distro_version "$PLATFORM" $DISTRO
+check_distro_version "$PLATFORM" $DISTRO $VERSION
 if [ $? -ne 0 ]; then
     echo "This version is not supported."
     print_supported_platforms

--- a/setup_meter.sh
+++ b/setup_meter.sh
@@ -437,21 +437,25 @@ function pre_install_sanity() {
 }
 
 # Grab some system information
-if [ $DISTRO = "CentOS" ] ; then
-         PLATFORM=`cat /etc/redhat-release | head -n 1`
-         DISTRO=`echo $PLATFORM | awk '{print $1}'`
-         MACHINE=`uname -m`
+if [ -f /etc/redhat-release ] ; then
+    PLATFORM=`cat /etc/redhat-release | head -n 1`
+    DISTRO=`echo $PLATFORM | awk '{print $1}'`
+    MACHINE=`uname -m`
+elif [ -f /etc/lsb-release ] ; then
+    #Ubuntu version lsb-release - https://help.ubuntu.com/community/CheckingYourUbuntuVersion
+    . /etc/lsb-release
+    OS=$DISTRIB_ID
+    VER=$DISTRIB_RELEASE
+    MACHINE=`uname -m`
+elif [ -f /etc/debian_version ] ; then
+    #Debian Version /etc/debian_version - Source: http://www.debian.org/doc/manuals/debian-faq/ch-software.en.html#s-isitdebian
+    PLATFORM=`cat /etc/debian_version | head -n 1`
+    DISTRO=`echo $PLATFORM | awk '{print $1}'`
+    MACHINE=`uname -m`
 else
-    test -f /etc/issue
-    if [ $? -eq 0 ]; then
-        PLATFORM=`cat /etc/issue | head -n 1`
-        DISTRO=`echo $PLATFORM | awk '{print $1}'`
-        MACHINE=`uname -m`
-    else
-        PLATFORM="unknown"
-        DISTRO="unknown"
-        MACHINE=`uname -m`
-    fi
+    PLATFORM="unknown"
+    DISTRO="unknown"
+    MACHINE=`uname -m`
 fi
 
 

--- a/setup_meter.sh
+++ b/setup_meter.sh
@@ -438,8 +438,9 @@ function pre_install_sanity() {
 
 # Grab some system information
 if [ -f /etc/redhat-release ] ; then
-    PLATFORM=`cat /etc/redhat-release | head -n 1`
-    DISTRO=`echo $PLATFORM | awk '{print $1}'`
+    PLATFORM=`cat /etc/redhat-release`
+    DISTRO=`echo ${PLATFORM:0:6}`
+    VERSION=`echo ${PLATFORM:15:3}`
     MACHINE=`uname -m`
 elif [ -f /etc/lsb-release ] ; then
     #Ubuntu version lsb-release - https://help.ubuntu.com/community/CheckingYourUbuntuVersion


### PR DESCRIPTION
I have created the methods to check if the version files exist on the machine and to parse data out of those files if they exist.

Your code check /etc/issue and this can be modified so that no longer contains the version data. The above should be a much cleaner method of detecting PLATFORM & DISTRO.
